### PR TITLE
Fix pyoxidizer multiprocessing on Windows

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -27,6 +27,11 @@ def parse_args():
         flags = None
     return flags
 
+def pyoxidizer_main():
+    from multiprocessing import freeze_support
+    freeze_support()
+    main()
+
 def main():
     flags = parse_args()
     with Timer():

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -37,9 +37,14 @@ def make_exe():
     # module.
     python_config.multiprocessing_start_method = 'auto'
 
+    # In version 0.19, there is a bug in the handling of the 'spawn' start method.
+    # This should be fixed in future versions but for now, I will call 'freeze_support'
+    # myself in the python code by using a different entry point for pyoxidizer.
+    python_config.multiprocessing_auto_dispatch = False
+
 
     # Evaluate a string as Python code when the interpreter starts.
-    python_config.run_command = "from app import main; main()"
+    python_config.run_command = "from app import pyoxidizer_main; pyoxidizer_main()"
 
     # Produce a PythonExecutable from a Python distribution, embedded
     # resources, and other options. The returned object represents the


### PR DESCRIPTION
In version 0.19 of PyOxidizer, there is a [bug](https://github.com/indygreg/PyOxidizer/commit/383e3f0bbb4c2a063579e45c0415378095b85ad3) in the handling of the 'spawn' start method. This should be fixed in future versions but for now, I will call 'freeze_support' myself in the python code by using a different entry point for pyoxidizer.