### PR TITLE
Get Nuitka working on Windows

### DIFF
--- a/install_monopoly.py
+++ b/install_monopoly.py
@@ -276,8 +276,9 @@ def nuitka(args, env):
     env.python(*split(NUITKA_BUILD_COMMAND))
     print("--- Done. Copying package file into dist/ ---")
     dist_dir.mkdir(parents=True, exist_ok=True)
-    monopoly_file = Path(NUITKA_BUILD_DIR) / "build" / f"monopoly{'.exe' if os.name == 'nt' else ''}"
-    shutil.copy2(monopoly_file, dist_dir)
+    monopoly_file_src = Path(NUITKA_BUILD_DIR) / "build" / f"monopoly{'.exe' if os.name == 'nt' else '.bin'}"
+    monopoly_file_dest = dist_dir / f"monopoly{'.exe' if os.name == 'nt' else ''}"
+    shutil.copy2(monopoly_file_src, monopoly_file_dest)
     print("--- Done. Files can be found in dist/ ---")
 
 @script_parser.parser(help_desc="Build a monopoly binary with all packaging tools.")

--- a/install_monopoly.py
+++ b/install_monopoly.py
@@ -275,6 +275,8 @@ def nuitka(args, env):
     shutil.copy2(Path("monopoly.py"), Path(NUITKA_BUILD_DIR))
     print("--- Done ---")
     print("--- Creating Nuitka single file executable. ---")
+    # Making the directories ourselves is only needed for Windows
+    # but is okay to do regardless of platform
     dist_dir.mkdir(parents=True, exist_ok=True)
     env.python(*split(NUITKA_BUILD_COMMAND))
     print("--- Done. Files can be found in dist/ ---")

--- a/install_monopoly.py
+++ b/install_monopoly.py
@@ -41,10 +41,10 @@ PYOXIDIZER_BUILD_COMMAND = f"""
 """
 
 NUITKA_BUILD_COMMAND = f"""
--m nuitka --enable-plugin=multiprocessing --onefile
-    --include-data-file {NUITKA_BUILD_DIR}/app/data/*.txt=app/data/
-    --output-dir {NUITKA_BUILD_DIR}/build
-    -o dist/nuitka/monopoly
+-m nuitka --onefile
+    --include-data-file={NUITKA_BUILD_DIR}/app/data/*.txt=app/data/
+    --output-dir={NUITKA_BUILD_DIR}/build
+    -o dist/nuitka/monopoly{'.exe' if os.name == 'nt' else ''}
     {NUITKA_BUILD_DIR}/monopoly.py
 """
 
@@ -268,12 +268,14 @@ def nuitka(args, env):
         print("--- Nuitka not installed. Run 'scriptopoly install' to install ---")
         return
     print("--- Building binary with Nuitka. ---")
-    shutil.rmtree(Path("dist/nuitka"), ignore_errors=True)
+    dist_dir = Path("dist/nuitka")
+    shutil.rmtree(dist_dir, ignore_errors=True)
     with extension_manager(build=args.no_extension):
         env.setup_py("build", "--build-lib", NUITKA_BUILD_DIR)
     shutil.copy2(Path("monopoly.py"), Path(NUITKA_BUILD_DIR))
     print("--- Done ---")
     print("--- Creating Nuitka single file executable. ---")
+    dist_dir.mkdir(parents=True, exist_ok=True)
     env.python(*split(NUITKA_BUILD_COMMAND))
     print("--- Done. Files can be found in dist/ ---")
 

--- a/install_monopoly.py
+++ b/install_monopoly.py
@@ -44,7 +44,6 @@ NUITKA_BUILD_COMMAND = f"""
 -m nuitka --onefile
     --include-data-file={NUITKA_BUILD_DIR}/app/data/*.txt=app/data/
     --output-dir={NUITKA_BUILD_DIR}/build
-    -o dist/nuitka/monopoly{'.exe' if os.name == 'nt' else ''}
     {NUITKA_BUILD_DIR}/monopoly.py
 """
 
@@ -253,7 +252,6 @@ def pyoxidizer(args, env):
     with extension_manager(build=args.no_extension):
         env.run(*split(PYOXIDIZER_BUILD_COMMAND))
     print("--- Done. Copying package files into dist/ ---")
-    dist_dir.mkdir(parents=True, exist_ok=True)
     for platform_dir in Path(PYOXIDIZER_BUILD_DIR).iterdir():
         install_dir = platform_dir / "release/install"
         shutil.copytree(install_dir, dist_dir, dirs_exist_ok=True)
@@ -275,10 +273,11 @@ def nuitka(args, env):
     shutil.copy2(Path("monopoly.py"), Path(NUITKA_BUILD_DIR))
     print("--- Done ---")
     print("--- Creating Nuitka single file executable. ---")
-    # Making the directories ourselves is only needed for Windows
-    # but is okay to do regardless of platform
-    dist_dir.mkdir(parents=True, exist_ok=True)
     env.python(*split(NUITKA_BUILD_COMMAND))
+    print("--- Done. Copying package file into dist/ ---")
+    dist_dir.mkdir(parents=True, exist_ok=True)
+    monopoly_file = Path(NUITKA_BUILD_DIR) / "build" / f"monopoly{'.exe' if os.name == 'nt' else ''}"
+    shutil.copy2(monopoly_file, dist_dir)
     print("--- Done. Files can be found in dist/ ---")
 
 @script_parser.parser(help_desc="Build a monopoly binary with all packaging tools.")

--- a/requirements-binaries.txt
+++ b/requirements-binaries.txt
@@ -1,6 +1,6 @@
 altgraph==0.17.2
 macholib==1.15.2
-Nuitka==0.6.19.4
+Nuitka==0.7.2
 pyinstaller==4.8
 pyinstaller-hooks-contrib==2022.0
 pyoxidizer==0.18.0


### PR DESCRIPTION
With this pull request the Nuitka built binary builds on Windows, woohoo!

There were two problems:
1. The output filename needed to have the `.exe` extension.
1. The directories for the output file path needed to exist.
 
The other changes in this pull request are related to upgrading the version of Nuitka