### PR TITLE
Add release.yml GH action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Build Release Binaries
+
+on:
+  release:
+    types: [published]
+
+
+jobs:
+  build:
+    name: Build & Add Binaries to Release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: [macos-12, windows-2022, ubuntu-22.04]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@4
+        with:
+          python-version: '3.10'
+      - name: Install Monopoly Virtual Environment
+        run: python install_monopoly.py
+      - run: source venv/bin/activate
+        if: runner.os != 'windows-2022'
+      - run: venv\Scripts\activate.bat
+        if: runner.os == 'windows-2022'
+      - name: Install Binary Requirements
+        run: scriptopoly install
+      - name: Build All Binaries
+        run: scriptopoly all_binaries
+      - name: Create tar.gz from dist folder
+        run: tar cvzf dist/Monopoly.tar.gz dist/*
+        if: runner.os != 'windows-2022'
+      - name: Create zip from dist folder
+        run: 7z a -tzip dist\Monopoly.zip dist\*
+        if: runner.os == 'windows-2022'
+      - name: Release Binaries
+        uses: softprops/action-gh-release@v1
+        with:
+          fail_on_unmatched_files: false
+          files: |
+            dist/Monopoly.tar.gz
+            dist\Monopoly.zip


### PR DESCRIPTION
This adds a GitHub Action workflow to build the monopoly binary assets when a release is published.

My intent here is to manually create a release, write up the release notes how I would like (and maybe use GitHub's auto generate feature to have something to start with), and then upon publishing the release this workflow will run and will add the binaries to it.

Another approach would be to generate the binaries on every push and run a basic test just to make sure they work *correctly*. Then you could have the CI ensure that a PR is okay to be merged into main and that a release from the head of main would be okay. For now I'll just test it manually, but I think this could be another option in the future.