### PR TITLE
Add archive-binaries command to script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,18 +24,14 @@ jobs:
         run: python install_monopoly.py
       - name: Install Binary Build Requirements
         run: scriptopoly install
+      - name: Set BUILD_DISTPATH Environment Variable
+        run: echo "BUILD_DISTPATH=monopoly-$(${{ github.ref }})-$(python -c "import platform; print(platform.platform())")" >> ${{ github.env }}
       - name: Build All Binaries
         run: scriptopoly all-binaries
-      - name: Create tar.gz from dist folder
-        if: runner.os != 'Windows'
-        run: tar cvzf dist/monopoly-${{ matrix.os }}-${{ runner.arch }}.tar.gz dist/*
-      - name: Create zip from dist folder
-        if: runner.os == 'Windows'
-        run: 7z a -tzip dist\monopoly-${{ matrix.os }}-${{ runner.arch }}.zip dist\*
+      - name: Create Build Archive
+        run: scriptopoly archive-binaries
       - name: Release Binaries
         uses: softprops/action-gh-release@v1
         with:
           fail_on_unmatched_files: false
-          files: |
-            dist/monopoly-${{ matrix.os }}-${{ runner.arch }}.tar.gz
-            dist\monopoly-${{ matrix.os }}-${{ runner.arch }}.zip
+          files: ${{ env.BUILD_DISTPATH }}.*


### PR DESCRIPTION
This will now handle the archiving of the binary builds to a zip or tar.gz file itself.

Also, it was becoming necessary to add a way to specify a custom location for the dist directory. So this takes care of making that change to any of the prior build commands that use the dist directory as well as the new archive command.