### PR TITLE
Fix distpath handling with PyInstaller

### DIFF
--- a/script/script.py
+++ b/script/script.py
@@ -252,7 +252,7 @@ def pyinstaller(args, env):
     shutil.copy2(Path("monopoly.py"), Path(PYINSTALLER_BUILD_DIR))
     print("--- Done ---")
     print("--- Creating PyInstaller single file executable. ---")
-    env.run(*split(PYINSTALLER_BUILD_COMMAND.format(distpath)))
+    env.run(*split(PYINSTALLER_BUILD_COMMAND.format(distpath.as_posix())))
     print(f"--- Done. File can be found in {distpath} ---")
 
 @script_parser.parser(help_desc="Build a monopoly binary with PyOxidizer.")


### PR DESCRIPTION
When passing the distpath value to the env command we first run it through `shlex.split`. This only works on posix strings, not windows strings. For this reason we need to make sure we pass the distpath into the `PYINSTALLER_BUILD_COMMAND` string as a posix string.

I have already experienced this problem before:
https://github.com/dunkmann00/Monopoly-Probabilities/blob/bef05123bdec4d30f61c2a1d770af29a650effc3/script/script.py#L16-L23