### PR TITLE
Upload binaries as artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get Build Name
         run: echo "BUILD_NAME=monopoly-${{ env.VERSION }}-$(python -c "import sysconfig; print(sysconfig.get_platform())")" >> ${{ github.env }}
       - name: Set BUILD_DISTPATH Environment Variable
-        run: echo "BUILD_DISTPATH=${{ runner.temp }}/dist/${{ env.BUILD_NAME }}" >> ${{ github.env }}
+        run: echo "BUILD_DISTPATH=$(python -c "import pathlib; print(pathlib.Path(r'${{ runner.temp }}') / 'dist' / '${{ env.BUILD_NAME }}')")" >> ${{ github.env }}
       - name: Setup keychain (macOS only)
         if: runner.os == 'macOS'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,9 +51,12 @@ jobs:
           # Also based on Github's guide for signing Xcode applications
           # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
 
-          # create path variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
+          # Make keychain temporary directory
+          mkdir $RUNNER_TEMP/keychain
+
+          # Create path variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/keychain/build_certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/keychain/build.keychain
 
           # Turn our base64-encoded certificate back to a regular .p12 file
           echo $MACOS_CERTIFICATE | base64 --decode > $CERTIFICATE_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: scriptopoly install
       - name: Get Version (non-release)
         if: github.event.release == null
-        run: echo "VERSION=$(git rev-parse --short ${{ github.sha }})" >> ${{ github.env }}
+        run: echo "VERSION=dev-$(git rev-parse --short ${{ github.sha }})" >> ${{ github.env }}
       - name: Get Version (release)
         if: github.event.release
         run: echo "VERSION=${{ github.ref_name }}" >> ${{ github.env }}
@@ -38,6 +38,10 @@ jobs:
         run: echo "BUILD_DISTPATH=monopoly-${{ env.VERSION }}-$(python -c "import sysconfig; print(sysconfig.get_platform())")" >> ${{ github.env }}
       - name: Setup keychain (macOS only)
         if: runner.os == 'macOS'
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
+          MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
         run: |
           # Based on blog post by Federico Terzi & Localazy:
           # https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/
@@ -45,45 +49,50 @@ jobs:
           # Also based on Github's guide for signing Xcode applications
           # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
 
-          # Turn our base64-encoded certificate back to a regular .p12 file
+          # create path variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
 
-          echo ${{ secrets.PROD_MACOS_CERTIFICATE }} | base64 --decode > certificate.p12
+          # Turn our base64-encoded certificate back to a regular .p12 file
+          echo $MACOS_CERTIFICATE | base64 --decode > $CERTIFICATE_PATH
 
           # We need to create a new keychain, otherwise using the certificate will prompt
           # with a UI dialog asking for the certificate password, which we can't
           # use in a headless CI environment
 
-          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
-
-          security create-keychain -p "${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}" $KEYCHAIN_PATH
+          # Create keychain
+          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
           security default-keychain -s $KEYCHAIN_PATH
-          security unlock-keychain -p "${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}" $KEYCHAIN_PATH
-          security import certificate.p12 -k $KEYCHAIN_PATH -P "${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}" -T /usr/bin/codesign
+          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" $KEYCHAIN_PATH
+
+          # Import certificate to keychain
+          security import $CERTIFICATE_PATH -k $KEYCHAIN_PATH -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
           security list-keychain -d user -s $KEYCHAIN_PATH
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}" $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" $KEYCHAIN_PATH
 
       - name: Build All Binaries (macOS Only)
         if: runner.os == 'macOS'
-        run: scriptopoly all-binaries --macos-codesign-identity "${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}"
+        env:
+          MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+        run: scriptopoly all-binaries --macos-codesign-identity "$MACOS_CERTIFICATE_NAME"
       - name: "Notarize app bundle (macOS Only)"
         if: runner.os == 'macOS'
+        env:
+          MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+          MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+          MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
         run: |
-          # Store the notarization credentials so that we can prevent a UI password dialog
-          # from blocking the CI
-
-          echo "Create keychain profile"
-          xcrun notarytool store-credentials "notarytool-profile" --apple-id "${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}" --team-id "${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}" --password "${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}"
-
           echo "Creating temp notarization archive"
           scriptopoly archive-binaries --base-name notary/notarization --format zip
 
           # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
           # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
-          # characteristics.
+          # characteristics. We pass in all the credentials, including the password so that we can prevent a
+          # UI password dialog from blocking the CI
 
           echo "Notarize app"
-          xcrun notarytool submit "notary/notarization.zip" --keychain-profile "notarytool-profile" --wait
+          xcrun notarytool submit "notary/notarization.zip" --apple-id "$MACOS_NOTARIZATION_APPLE_ID" --team-id "$MACOS_NOTARIZATION_TEAM_ID" --password "$MACOS_NOTARIZATION_PWD" --wait
 
           # This is where we would normally "attach the staple" to our executable. Unfortunately that can't be done at
           # this time:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.BUILD_NAME }}
-          path: ${{ env.BUILD_DISTPATH }}.*
+          path: |
+            ${{ env.BUILD_DISTPATH }}.zip # Needed to avoid including all the intermediate directories in the zip -_-
+            ${{ env.BUILD_DISTPATH }}.tar.gz
           if-no-files-found: error
       - name: Release Binary Archive
         if: github.event.release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,10 @@ jobs:
       - name: Get Version (release)
         if: github.event.release
         run: echo "VERSION=${{ github.ref_name }}" >> ${{ github.env }}
+      - name: Get Build Name
+        run: echo "BUILD_NAME=monopoly-${{ env.VERSION }}-$(python -c "import sysconfig; print(sysconfig.get_platform())")" >> ${{ github.env }}
       - name: Set BUILD_DISTPATH Environment Variable
-        run: echo "BUILD_DISTPATH=monopoly-${{ env.VERSION }}-$(python -c "import sysconfig; print(sysconfig.get_platform())")" >> ${{ github.env }}
+        run: echo "BUILD_DISTPATH=${{ runner.temp }}/dist/${{ env.BUILD_NAME }}" >> ${{ github.env }}
       - name: Setup keychain (macOS only)
         if: runner.os == 'macOS'
         env:
@@ -114,7 +116,7 @@ jobs:
         # https://github.com/actions/upload-artifact/blob/v3/README.md#zipped-artifact-downloads
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.BUILD_DISTPATH }}
+          name: ${{ env.BUILD_NAME }}
           path: ${{ env.BUILD_DISTPATH }}.*
           if-no-files-found: error
       - name: Release Binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,4 +129,4 @@ jobs:
         if: github.event.release
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{ env.BUILD_DISTPATH }}.*
+          files: ${{ env.BUILD_DISTPATH }}.*(zip|tar.gz)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       NO_VIRTUAL_ENV: 1
+      PYTHONUNBUFFERED: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,8 @@ jobs:
           MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
         run: |
           echo "Creating temp notarization archive"
-          scriptopoly archive-binaries --base-name notary/notarization --format zip
+          NOTARIZATION_PATH=$RUNNER_TEMP/notary/notarization
+          scriptopoly archive-binaries --base-name $NOTARIZATION_PATH --format zip
 
           # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
           # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
@@ -94,7 +95,7 @@ jobs:
           # UI password dialog from blocking the CI
 
           echo "Notarize app"
-          xcrun notarytool submit "notary/notarization.zip" --apple-id "$MACOS_NOTARIZATION_APPLE_ID" --team-id "$MACOS_NOTARIZATION_TEAM_ID" --password "$MACOS_NOTARIZATION_PWD" --wait
+          xcrun notarytool submit "$NOTARIZATION_PATH.zip" --apple-id "$MACOS_NOTARIZATION_APPLE_ID" --team-id "$MACOS_NOTARIZATION_TEAM_ID" --password "$MACOS_NOTARIZATION_PWD" --wait
 
           # This is where we would normally "attach the staple" to our executable. Unfortunately that can't be done at
           # this time:
@@ -108,9 +109,9 @@ jobs:
       - name: Build All Binaries
         if: runner.os != 'macOS'
         run: scriptopoly all-binaries
-      - name: Create Release Archive
+      - name: Create Binary Archive
         run: scriptopoly archive-binaries
-      - name: Upload Binaries
+      - name: Upload Binary Archive
         # Even though downloading artifacts wraps them in another zip file we still want to archive
         # the binaries ourselves. Doing so preserves file permissions and keeps the binaries exectuable.
         # https://github.com/actions/upload-artifact/blob/v3/README.md#zipped-artifact-downloads
@@ -119,7 +120,7 @@ jobs:
           name: ${{ env.BUILD_NAME }}
           path: ${{ env.BUILD_DISTPATH }}.*
           if-no-files-found: error
-      - name: Release Binaries
+      - name: Release Binary Archive
         if: github.event.release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           name: ${{ env.BUILD_NAME }}
           path: |
-            ${{ env.BUILD_DISTPATH }}.zip # Needed to avoid including all the intermediate directories in the zip -_-
+            ${{ env.BUILD_DISTPATH }}.zip
             ${{ env.BUILD_DISTPATH }}.tar.gz
           if-no-files-found: error
       - name: Release Binary Archive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,16 @@
-name: Build Release Binaries
+name: Build Binaries
 
 on:
+  push:
+    branches: [main]
+  pull_request:
   release:
     types: [published]
 
 
 jobs:
   build:
-    name: Build & Release
+    name: Build
     runs-on: ${{ matrix.os }}
     env:
       NO_VIRTUAL_ENV: 1
@@ -24,8 +27,14 @@ jobs:
         run: python install_monopoly.py
       - name: Install Binary Build Requirements
         run: scriptopoly install
+      - name: Get Version (non-release)
+        if: github.event.release == null
+        run: echo "VERSION=$(git rev-parse --short ${{ github.sha }})" >> ${{ github.env }}
+      - name: Get Version (release)
+        if: github.event.release
+        run: echo "VERSION=${{ github.ref_name }}" >> ${{ github.env }}
       - name: Set BUILD_DISTPATH Environment Variable
-        run: echo "BUILD_DISTPATH=monopoly-${{ github.ref_name }}-$(python -c "import sysconfig; print(sysconfig.get_platform())")" >> ${{ github.env }}
+        run: echo "BUILD_DISTPATH=monopoly-${{ env.VERSION }}-$(python -c "import sysconfig; print(sysconfig.get_platform())")" >> ${{ github.env }}
       - name: Setup keychain (macOS only)
         if: runner.os == 'macOS'
         run: |
@@ -49,7 +58,7 @@ jobs:
 
       - name: Build All Binaries (macOS Only)
         if: runner.os == 'macOS'
-        run: scriptopoly all-binaries --macos-codesign-identity ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+        run: scriptopoly all-binaries --macos-codesign-identity "${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}"
       - name: "Notarize app bundle (macOS Only)"
         if: runner.os == 'macOS'
         run: |
@@ -81,9 +90,19 @@ jobs:
       - name: Build All Binaries
         if: runner.os != 'macOS'
         run: scriptopoly all-binaries
-      - name: Create Build Archive
+      - name: Create Release Archive
         run: scriptopoly archive-binaries
+      - name: Upload Binaries
+        # Even though downloading artifacts wraps them in another zip file we still want to archive
+        # the binaries ourselves. Doing so preserves file permissions and keeps the binaries exectuable.
+        # https://github.com/actions/upload-artifact/blob/v3/README.md#zipped-artifact-downloads
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.BUILD_DISTPATH }}
+          path: ${{ env.BUILD_DISTPATH }}.*
+          if-no-files-found: error
       - name: Release Binaries
+        if: github.event.release
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.BUILD_DISTPATH }}.*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.BUILD_NAME }}
+          # By entering the paths separately we get the parent directory as the root, which is what we want
           path: |
             ${{ env.BUILD_DISTPATH }}.zip
             ${{ env.BUILD_DISTPATH }}.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ jobs:
           # Based on blog post by Federico Terzi & Localazy:
           # https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/
           # https://localazy.com/blog/how-to-automatically-sign-macos-apps-using-github-actions
+          # Also based on Github's guide for signing Xcode applications
+          # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
 
           # Turn our base64-encoded certificate back to a regular .p12 file
 
@@ -51,11 +53,15 @@ jobs:
           # with a UI dialog asking for the certificate password, which we can't
           # use in a headless CI environment
 
-          security create-keychain -p "${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}" build.keychain
-          security import certificate.p12 -k build.keychain -P "${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}" build.keychain
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
+
+          security create-keychain -p "${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security default-keychain -s $KEYCHAIN_PATH
+          security unlock-keychain -p "${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}" $KEYCHAIN_PATH
+          security import certificate.p12 -k $KEYCHAIN_PATH -P "${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}" -T /usr/bin/codesign
+          security list-keychain -d user -s $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}" $KEYCHAIN_PATH
 
       - name: Build All Binaries (macOS Only)
         if: runner.os == 'macOS'

--- a/scripts/scripts/scriptopoly.py
+++ b/scripts/scripts/scriptopoly.py
@@ -205,7 +205,7 @@ def archive_binaries(args, env):
     distpath = Path(distpath)
     base_name = args.base_name or str(distpath)
     format = args.format or ('zip' if os.name == 'nt' else 'gztar')
-    archive_name = shutil.make_archive(base_name, format, base_dir=distpath)
+    archive_name = shutil.make_archive(base_name, format, root_dir=distpath.parent, base_dir=distpath.name)
     print(f"--- Done. Archive can be found at {archive_name} ---")
 
 def main():

--- a/scripts/scripts/scriptopoly.py
+++ b/scripts/scripts/scriptopoly.py
@@ -128,7 +128,7 @@ def pyinstaller(args, env):
     print("--- Creating PyInstaller single file executable. ---")
     build_command = PYINSTALLER_BUILD_COMMAND
     if sys.platform == 'darwin' and args.macos_codesign_identity:
-        build_command += f"--codesign-identity {args.macos_codesign_identity}"
+        build_command += f"--codesign-identity \"{args.macos_codesign_identity}\""
     env.run(*split(build_command.format(distpath.as_posix())))
     print(f"--- Done. File can be found in {distpath} ---")
 
@@ -177,7 +177,7 @@ def nuitka(args, env):
     print("--- Creating Nuitka single file executable. ---")
     build_command = NUITKA_BUILD_COMMAND
     if sys.platform == 'darwin' and args.macos_codesign_identity:
-        build_command += f"--macos-sign-identity={args.macos_codesign_identity} --macos-sign-notarization"
+        build_command += f"--macos-sign-identity=\"{args.macos_codesign_identity}\" --macos-sign-notarization"
     env.python(*split(build_command))
     print(f"--- Done. Copying package file into {distpath} ---")
     distpath.mkdir(parents=True, exist_ok=True)

--- a/scripts/scripts/scriptopoly.py
+++ b/scripts/scripts/scriptopoly.py
@@ -149,7 +149,7 @@ def pyoxidizer(args, env):
     print("--- Signing Binaries ---")
     if sys.platform == 'darwin' and args.macos_codesign_identity:
         files = glob.glob(f"{PYOXIDIZER_BUILD_DIR}/**/monopoly*", recursive=True)
-        env.run("/usr/bin/codesign", "--force", "-s", args.macos_codesign_identity, "--options", "runtime", *files, "-v")
+        env.run("/usr/bin/codesign", "--force", "-s", args.macos_codesign_identity, "--timestamp", "--options", "runtime", *files, "-v")
     print(f"--- Done. Copying package files into {distpath} ---")
     for platform_dir in Path(PYOXIDIZER_BUILD_DIR).iterdir():
         install_dir = platform_dir / "release/install"

--- a/scripts/scripts/scriptopoly.py
+++ b/scripts/scripts/scriptopoly.py
@@ -28,6 +28,14 @@ if os.name == 'nt':
     if PYOXIDIZER:
         PYOXIDIZER = Path(PYOXIDIZER).as_posix()
 
+    if PYINSTALLER_BUILD_DIR:
+        PYINSTALLER_BUILD_DIR = Path(PYINSTALLER_BUILD_DIR).as_posix()
+    if PYOXIDIZER_BUILD_DIR:
+        PYOXIDIZER_BUILD_DIR = Path(PYOXIDIZER_BUILD_DIR).as_posix()
+    if NUITKA_BUILD_DIR:
+        NUITKA_BUILD_DIR = Path(NUITKA_BUILD_DIR).as_posix()
+
+
 BUILD_ARTIFACTS = [
     "build",
     "dist*",


### PR DESCRIPTION
This will upload the built binaries as artifacts for all PRs, pushes to the main branch, and on releases.

On releases, we still also upload the binaries directly to the release.