### PR TITLE
Always make BUILD_DISTPATH a posix path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get Build Name
         run: echo "BUILD_NAME=monopoly-${{ env.VERSION }}-$(python -c "import sysconfig; print(sysconfig.get_platform())")" >> ${{ github.env }}
       - name: Set BUILD_DISTPATH Environment Variable
-        run: echo "BUILD_DISTPATH=$(python -c "import pathlib; print(pathlib.Path(r'${{ runner.temp }}') / 'dist' / '${{ env.BUILD_NAME }}')")" >> ${{ github.env }}
+        run: echo "BUILD_DISTPATH=$(python -c "import pathlib; print( (pathlib.Path(r'${{ runner.temp }}') / 'dist' / '${{ env.BUILD_NAME }}').as_posix() )")" >> ${{ github.env }}
       - name: Setup keychain (macOS only)
         if: runner.os == 'macOS'
         env:


### PR DESCRIPTION
After `action-gh-release` was updated globs are handled differently. This is because the glob library it uses was updated. The updated glob library always interprets backslashes as escape characters. This means if BUILD_DISTPATH has backslashes in it, `action-gh-release` won't match it correctly and won't upload our archives. To fix this, we can make sure to always use a posix path.