### PR TITLE
Let PyOxidizer handle multiprocessing on its own

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -34,11 +34,6 @@ def parse_args():
         flags = None
     return flags
 
-def pyoxidizer_main():
-    from multiprocessing import freeze_support
-    freeze_support()
-    main()
-
 def main():
     flags = parse_args()
 

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -36,15 +36,11 @@ def make_exe():
     # appropriate value when OxidizedFinder imports the `multiprocessing`
     # module.
     python_config.multiprocessing_start_method = 'auto'
-
-    # In version 0.19, there is a bug in the handling of the 'spawn' start method.
-    # This should be fixed in future versions but for now, I will call 'freeze_support'
-    # myself in the python code by using a different entry point for pyoxidizer.
-    python_config.multiprocessing_auto_dispatch = False
+    python_config.multiprocessing_auto_dispatch = True
 
 
     # Evaluate a string as Python code when the interpreter starts.
-    python_config.run_command = "from app import pyoxidizer_main; pyoxidizer_main()"
+    python_config.run_command = "from app import main; main()"
 
     # Produce a PythonExecutable from a Python distribution, embedded
     # resources, and other options. The returned object represents the


### PR DESCRIPTION
PyOxidizer now properly supports the multiprocessing module. This removes the code that was working around that limitation.