### PR TITLE
Fix Keyboard Interrupts Windows

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,7 @@ from rich.panel import Panel
 from rich.text import Text
 from rich import box
 
+SPINNER = 'bouncingBar' if os.name == 'nt' else 'dots'
 
 # This is needed to turn off multiprocessing when built with Nuitka.
 # No matter what I tried I couldn't get it to work. Hopefully I can fix
@@ -80,7 +81,7 @@ def main():
         info_template = f"Using [{{color}}]{pluralize(num_cores_used,'core',highlight=True)}[/] to simulate [{{color}}]{pluralize(sum(turns),'move',',',True)}[/]"
         info_text = info_template.format(color="green")
         cancelled_text = info_template.format(color="red") + "[white]...[/][bold red]Cancelled"
-        with cancel_on_kbinterrupt(cancelled_text), console.status(info_text) as console_status:
+        with cancel_on_kbinterrupt(cancelled_text), console.status(info_text, spinner=SPINNER) as console_status:
             if len(turns) <= 1 or NUITKA_BUILD:
                 results = [sum(square) for square in zip(*starmap(play_game, generate_games(monopoly_cls, turns)))]
             else:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-import os
+import os, time
 from multiprocessing import Pool
 from itertools import starmap
 from .utils import (Timer, Result, pluralize, init_worker, cancel_on_kbinterrupt,
@@ -86,7 +86,10 @@ def main():
                 results = [sum(square) for square in zip(*starmap(play_game, generate_games(monopoly_cls, turns)))]
             else:
                 with Pool(initializer=init_worker) as pool:
-                    results = [sum(square) for square in zip(*pool.starmap(play_game, generate_games(monopoly_cls, turns)))]
+                    processing = pool.starmap_async(play_game, generate_games(monopoly_cls, turns))
+                    while not processing.ready():
+                        time.sleep(0.1)
+                    results = [sum(square) for square in zip(*processing.get())]
 
     result = Result(results, timer.duration, num_cores_used)
     console.rule("[bold]Results")

--- a/app/utils.py
+++ b/app/utils.py
@@ -247,7 +247,7 @@ def save_results(result, results_dir=None):
     with resources.open_text(data, 'board-spaces.txt') as fp_board_spaces:
         board_spaces = [BoardSpace(*value.rstrip().split(":")) for value in fp_board_spaces]
 
-    console.print(f"\n[bold]Saving in[/] {results_dir}:")
+    console.print(f"\n[bold]Saving in[/] [magenta]{results_dir}[/]:")
 
     probs_txt = results_dir / 'board-probabilities.txt'
     probs_csv = results_dir / 'board-probabilities.csv'


### PR DESCRIPTION
It seems that even though I had gotten the keyboard interrupts working on macOS, they still didn't want to work on Windows when ran in multi-core mode. This change fixes that problem by switching to `starmap_async` and then manually looping and sleeping until it is ready. This seems to give the interrupts a chance to be processed on Windows while also not adding a performance penalty.

I also tested this on my Mac and the same was true. I won't bother adding a conditional check to only do it this way on Windows since it seems to not have any negative effects on macOS.