### PR TITLE
Setup GitHub Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+exclude: ["*"]
+include: ["README.md", "title-image.png"]


### PR DESCRIPTION
Only include the `README.md` and `title-image.png` in the site build. For now, all settings can just be configured with the default ones GH pages uses when there is no config.

This was working fine, until it stopped actually building the `README.md` and now the `css` is not getting loaded...I think I may merge this and see what happens.